### PR TITLE
add timeout between requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^1.0.0-beta.42",
     "axios": "^0.18.0",
+    "bluebird": "^3.7.2",
     "bootstrap": "^4.0.0",
     "classnames": "^2.2.6",
     "downloadjs": "^1.4.7",

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -81,7 +81,7 @@ export const jawgAPI = {
      }
      const mappedResponses = _.map(allResp, resp => {
        return _.map(resp.data, (pt) => {
-         const { elevation } = pt;
+          const  elevation  = (pt.elevation * FEET_PER_METER);
          const latitude = pt.location.lat;
          const longitude = pt.location.lng;
          return { elevation, latitude, longitude };


### PR DESCRIPTION
This PR adds a timeout of 5 seconds between requests to grab 100 hydrant elevations at a time. Since this translates to resolving each promise in an array of promises sequentially, this PR implements [bluebird](http://bluebirdjs.com/docs/getting-started.html) which allow us to control the concurrency of requests. In contrast, Axios.all(<array_of_promises>) executes all promises passed concurrently..so setting a timeout on each of those doesn't do anything. 
